### PR TITLE
Не ломайте работу моего модуля своим кэшером!

### DIFF
--- a/oc23/upload/system/library/v2pagecache.php
+++ b/oc23/upload/system/library/v2pagecache.php
@@ -45,7 +45,8 @@ class V2PageCache {
         '#/wishlist/#',
         '#/compare/#',
         '#/captcha#',
-        '#/admin#'
+        '#/admin#',
+        '#feed/yandex_yml#'
     );
 
     private $cachefile=null;   // null specifically meaning "not known yet"


### PR DESCRIPTION
YML-фид выводится через echo, а не $this->response->setOutput и кэшер выдает пустоту.