### PR TITLE
nested SESSION array fix

### DIFF
--- a/oc23/upload/system/library/v2pagecache.php
+++ b/oc23/upload/system/library/v2pagecache.php
@@ -245,6 +245,16 @@ class V2PageCache {
         } 
         $svar=$this->GetSessionVar();
         // don't cache for logged in customers or affiliates
+		/**
+         * if data in _SESSION has a nested array
+         * that requires a another one check
+         */
+        $logged = false;
+        foreach ($svar as $sval) {
+            if (!empty($sval['customer_id']) || !empty($sval['affiliate_id'])) {
+                $logged = true;
+            }
+        }
         if( !empty($svar['customer_id']) || !empty($svar['affiliate_id'])) {
             $this->cacheable=false;
             return $this->cacheable;


### PR DESCRIPTION
In my case, `$_SESSION` has 
`array(1) {
  ["p17kup4359h5crkoc4l7dnkj05"]=>
  array(7) {
    ["customer_id"]=>
    string(2) "90"
    ["token"]=>
    string(32) "2FfmmR...`
so `$this->cacheable` is always `true` in this point.
This seems to be caused by other extensions, OC version, or a feature of the project. Therefore, just in case, I think it is necessary to add one more check.